### PR TITLE
Allow use of concise query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,17 @@ objectql(source, { a: false }); // returns {}
 objectql(source, { a: function noop() {} }); // returns {}
 
 
-// valid query key values
+// valid query key values using <string> query
 objectql(source, '{ a }'); // returns { a: 'a' }
 objectql(source, '{ b }'); // returns { b: { c: 'c', d: 'd' } }
 objectql(source, '{ a b { c } }'); // returns { a: 'a', b: { c: 'c' } }
+
+// valid query key values using <object> query
+objectql(source, { a: true }); // returns { a: 'a' }
+objectql(source, { b: true }); // returns { b: { c: 'c', d: 'd' } }
+objectql(source, { a: true, b: { c: true } }); // returns { a: 'a', b: { c: 'c' } }
+
+
 ```
 
 ## examples

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Performance. Reducing an API payload, picking only what you actually need means 
 __source__ must be an object or an array:
 
 ```js
-const query = {
-  a: true
-};
+const query = `{
+  a
+}`;
 
 // invalid source values
 objectql(null, query); // returns null
@@ -37,7 +37,7 @@ objectql({ a: 'a', b: 'b' }, query); // returns { a: 'a' }
 objectql([{ a: 'a', b: 'b' }, { b: 'b', c: 'c' }], query); // returns [{ a: 'a' }, {}]
 ```
 
-__query__ must be an object, and only the keys where the value is `true` will be used. If an object is used as a key's value it will apply that object as the `query` param to that part of the source object recursively.
+__query__ must be a concise string of key names, like a 'simple' graphql query.
 
 ```js
 const source = {
@@ -67,14 +67,14 @@ objectql(source, { a: function noop() {} }); // returns {}
 
 
 // valid query key values
-objectql(source, { a: true }); // returns { a: 'a' }
-objectql(source, { b: true }); // returns { b: { c: 'c', d: 'd' } }
-objectql(source, { a: true, b: { c: true } }); // returns { a: 'a', b: { c: 'c' } }
+objectql(source, '{ a }'); // returns { a: 'a' }
+objectql(source, '{ b }'); // returns { b: { c: 'c', d: 'd' } }
+objectql(source, '{ a b { c } }'); // returns { a: 'a', b: { c: 'c' } }
 ```
 
 ## examples
 
-The query object follows a similar pattern to a 'simple' graphql query, for each key in the query `objectql` will pick the matching key from the source object when the query value is `true`.
+The query object follows a similar pattern to a 'simple' graphql query, for each key in the query `objectql` will pick the matching key from the source object.
 
 ```js
 const source = {
@@ -89,13 +89,13 @@ const source = {
   }
 };
 
-const query = {
-  id: true,
-  username: true,
-  location: {
-    postCode: true
+const query = `{
+  id
+  username
+  location {
+    postCode
   }
-};
+}`;
 
 const result = objectql(source, query);
 
@@ -147,13 +147,13 @@ const source = [
     }
   }
 ];
-const query = {
-  b: {
-    c: {
-      d: true
+const query = `{
+  b {
+    c {
+      d
     }
   }
-};
+}`;
 
 const result = objectql(source, query);
 
@@ -193,13 +193,13 @@ If the source object is not an object or an array it will be returned back as th
 
 ```js
 const source = null;
-const query = {
-  a: {
-    b: {
-      c: true
+const query = `{
+  a {
+    b {
+      c
     }
   }
-};
+}`;
 
 const result = objectql(source, query);
 
@@ -216,13 +216,13 @@ const source = {
     b: null
   }
 };
-const query = {
+const query = `{
   a: {
     b: {
-      c: true
+      c
     }
   }
-};
+}`;
 
 const result = objectql(source, query);
 
@@ -279,16 +279,16 @@ const source = {
     }
   ]
 };
-const query = {
-  id: true,
-  items: {
-    modelName: true,
-    url: true,
-    photos: {
-      url: true
+const query = `{
+  id
+  items {
+    modelName
+    url
+    photos {
+      url
     }
   }
-};
+}`;
 const result = objectql(source, query);
 
 // result will be:
@@ -314,7 +314,7 @@ const result = objectql(source, query);
       ]
     }
   ]
-};
+}
 ```
 
 Still not sure, take a look at the [tests](https://github.com/bmullan91/objectql/tree/master/test) for more examples.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ const source = {
 // invalid queries
 objectql(source, null); // returns source
 objectql(source, undefined); // returns source
-objectql(source, ''); // returns source
 objectql(source, 10); // returns source
 objectql(source, true); // returns source
 objectql(source, false); // returns source
@@ -77,6 +76,9 @@ objectql(source, { b: true }); // returns { b: { c: 'c', d: 'd' } }
 objectql(source, { a: true, b: { c: true } }); // returns { a: 'a', b: { c: 'c' } }
 
 
+// invalid string queries
+objectql(source, '') // throws
+objectql(source, '{ hello }}') // throws
 ```
 
 ## examples

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ objectql(source, '{ a b { c } }'); // returns { a: 'a', b: { c: 'c' } }
 
 ## examples
 
-The query object follows a similar pattern to a 'simple' graphql query, for each key in the query `objectql` will pick the matching key from the source object.
+The query object follows a similar pattern to a 'simple' graphql query, for each key in the query `objectql` will pick the matching key from the source object. In the examples below we'll be using the string graphql-like queries.
 
 ```js
 const source = {

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ objectql({ a: 'a', b: 'b' }, query); // returns { a: 'a' }
 objectql([{ a: 'a', b: 'b' }, { b: 'b', c: 'c' }], query); // returns [{ a: 'a' }, {}]
 ```
 
-__query__ must be a concise string of key names, like a 'simple' graphql query.
+__query__ can be either a string or an object, see below for examples.
 
 ```js
 const source = {

--- a/index.js
+++ b/index.js
@@ -1,18 +1,46 @@
 const isObject = require('isobject');
 
+function parse(query) {
+  if (isObject(query)) {
+    return query;
+  }
+  try {
+    return JSON.parse(
+      query
+        .replace(/(?:\r\n|\r|\n)|,|:/g, ' ')
+        .replace(/ +/g, ' ')
+        .trim()
+        .replace(/([^ {}]+) /g, '"$1" ')
+        .replace(/" "/g, '":true, "')
+        .replace(/} "/g, '}, "')
+        .replace(/" {/g, '": {')
+        .replace(/" }/g, '":true }')
+    );
+  } catch (error) {
+    return null;
+  }
+}
+
 module.exports = function objectql(source, query) {
-  if ((!Array.isArray(source) && !isObject(source)) || !isObject(query)) {
+  if (!Array.isArray(source) && !isObject(source)) {
+    return source;
+  }
+
+  // eslint-disable-next-line no-param-reassign
+  query = parse(query);
+
+  if (!isObject(query)) {
     return source;
   }
 
   if (Array.isArray(source)) {
-    return source.map((item) => objectql(item, query));
+    return source.map(item => objectql(item, query));
   }
 
   const sourceKeys = Object.keys(source);
 
   return Object.keys(query)
-    .filter((key) => !!~sourceKeys.indexOf(key))
+    .filter(key => !!~sourceKeys.indexOf(key))
     .reduce((newSource, key) => {
       if (query[key] === true) {
         return Object.assign({}, newSource, {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const isObject = require('isobject');
 
 function parse(query) {
-  if (isObject(query)) {
+  if (typeof query !== 'string') {
     return query;
   }
   try {

--- a/index.js
+++ b/index.js
@@ -18,7 +18,9 @@ function parse(query) {
         .replace(/" }/g, '":true }')
     );
   } catch (error) {
-    return null;
+    // eslint-disable-next-line no-console
+    console.error(`Invalid objectql query: ${query}`);
+    throw error;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ function parse(query) {
     return JSON.parse(
       query
         .replace(/(?:\r\n|\r|\n)|,|:/g, ' ')
+        .replace(/([{}])/g, ' $1 ')
         .replace(/ +/g, ' ')
         .trim()
         .replace(/([^ {}]+) /g, '"$1" ')

--- a/index.js
+++ b/index.js
@@ -27,31 +27,30 @@ module.exports = function objectql(source, query) {
     return source;
   }
 
-  // eslint-disable-next-line no-param-reassign
-  query = parse(query);
+  const parsedQuery = parse(query);
 
-  if (!isObject(query)) {
+  if (!isObject(parsedQuery)) {
     return source;
   }
 
   if (Array.isArray(source)) {
-    return source.map(item => objectql(item, query));
+    return source.map(item => objectql(item, parsedQuery));
   }
 
   const sourceKeys = Object.keys(source);
 
-  return Object.keys(query)
+  return Object.keys(parsedQuery)
     .filter(key => !!~sourceKeys.indexOf(key))
     .reduce((newSource, key) => {
-      if (query[key] === true) {
+      if (parsedQuery[key] === true) {
         return Object.assign({}, newSource, {
           [key]: source[key]
         });
       }
 
-      if (isObject(query[key])) {
+      if (isObject(parsedQuery[key])) {
         return Object.assign({}, newSource, {
-          [key]: objectql(source[key], query[key])
+          [key]: objectql(source[key], parsedQuery[key])
         });
       }
 

--- a/test/query-validation.js
+++ b/test/query-validation.js
@@ -5,7 +5,7 @@ const objectql = require('../');
 // shortcuts
 const test = tap.test;
 
-test('it should return the same source if the query is null', (t) => {
+test('it should return the same source if the query is null', t => {
   t.plan(1);
   const source = {
     key: 'value'
@@ -19,21 +19,7 @@ test('it should return the same source if the query is null', (t) => {
   t.deepEqual(actual, expected);
 });
 
-test('it should return the same source if the query is an empty string', (t) => {
-  t.plan(1);
-  const source = {
-    key: 'value'
-  };
-  const query = '';
-  const actual = objectql(source, query);
-  const expected = {
-    key: 'value'
-  };
-
-  t.deepEqual(actual, expected);
-});
-
-test('it should return the same source if the query is a number', (t) => {
+test('it should return the same source if the query is a number', t => {
   t.plan(1);
   const source = {
     key: 'value'
@@ -47,7 +33,7 @@ test('it should return the same source if the query is a number', (t) => {
   t.deepEqual(actual, expected);
 });
 
-test('it should return the same source if the query is undefined', (t) => {
+test('it should return the same source if the query is undefined', t => {
   t.plan(1);
   const source = {
     key: 'value'
@@ -61,7 +47,7 @@ test('it should return the same source if the query is undefined', (t) => {
   t.deepEqual(actual, expected);
 });
 
-test('it should return the same source if the query is true', (t) => {
+test('it should return the same source if the query is true', t => {
   t.plan(1);
   const source = {
     key: 'value'
@@ -75,7 +61,7 @@ test('it should return the same source if the query is true', (t) => {
   t.deepEqual(actual, expected);
 });
 
-test('it should return the same source if the query is false', (t) => {
+test('it should return the same source if the query is false', t => {
   t.plan(1);
   const source = {
     key: 'value'
@@ -89,7 +75,7 @@ test('it should return the same source if the query is false', (t) => {
   t.deepEqual(actual, expected);
 });
 
-test('it should return the same source if the query is a function', (t) => {
+test('it should return the same source if the query is a function', t => {
   t.plan(1);
   const source = {
     key: 'value'
@@ -103,7 +89,7 @@ test('it should return the same source if the query is a function', (t) => {
   t.deepEqual(actual, expected);
 });
 
-test('it should return the same source if the query is an array', (t) => {
+test('it should return the same source if the query is an array', t => {
   t.plan(1);
   const source = {
     key: 'value'
@@ -117,7 +103,7 @@ test('it should return the same source if the query is an array', (t) => {
   t.deepEqual(actual, expected);
 });
 
-test('it should return an empty source if the query is an empty object', (t) => {
+test('it should return an empty source if the query is an empty object', t => {
   t.plan(1);
   const source = {
     key: 'value'
@@ -131,7 +117,7 @@ test('it should return an empty source if the query is an empty object', (t) => 
 
 // query is an object - but the key values must only be 'true'
 
-test('it should ignore query keys when their value is null', (t) => {
+test('it should ignore query keys when their value is null', t => {
   t.plan(1);
   const source = {
     key: 'value'
@@ -145,7 +131,7 @@ test('it should ignore query keys when their value is null', (t) => {
   t.deepEqual(actual, expected);
 });
 
-test('it should ignore query keys when their value is an empty string', (t) => {
+test('it should ignore query keys when their value is an empty string', t => {
   t.plan(1);
   const source = {
     key: 'value'
@@ -159,7 +145,7 @@ test('it should ignore query keys when their value is an empty string', (t) => {
   t.deepEqual(actual, expected);
 });
 
-test('it should ignore query keys when their value is a number', (t) => {
+test('it should ignore query keys when their value is a number', t => {
   t.plan(1);
   const source = {
     key: 'value'
@@ -173,7 +159,7 @@ test('it should ignore query keys when their value is a number', (t) => {
   t.deepEqual(actual, expected);
 });
 
-test('it should ignore query keys when their value is undefined', (t) => {
+test('it should ignore query keys when their value is undefined', t => {
   t.plan(1);
   const source = {
     key: 'value'
@@ -187,7 +173,7 @@ test('it should ignore query keys when their value is undefined', (t) => {
   t.deepEqual(actual, expected);
 });
 
-test('it should ignore query keys when their value is false', (t) => {
+test('it should ignore query keys when their value is false', t => {
   t.plan(1);
   const source = {
     key: 'value'
@@ -201,7 +187,7 @@ test('it should ignore query keys when their value is false', (t) => {
   t.deepEqual(actual, expected);
 });
 
-test('it should ignore query keys when their value is a function', (t) => {
+test('it should ignore query keys when their value is a function', t => {
   t.plan(1);
   const source = {
     key: 'value'
@@ -215,7 +201,7 @@ test('it should ignore query keys when their value is a function', (t) => {
   t.deepEqual(actual, expected);
 });
 
-test('it should ignore query keys when their value is an array', (t) => {
+test('it should ignore query keys when their value is an array', t => {
   t.plan(1);
   const source = {
     key: 'value'
@@ -229,7 +215,7 @@ test('it should ignore query keys when their value is an array', (t) => {
   t.deepEqual(actual, expected);
 });
 
-test('it should return the key & value if its not an object/array that the query expected', (t) => {
+test('it should return the key & value if its not an object/array that the query expected', t => {
   t.plan(1);
   const source = {
     key: 'value'
@@ -247,7 +233,7 @@ test('it should return the key & value if its not an object/array that the query
   t.deepEqual(actual, expected);
 });
 
-test('it should return the same source key value if the query key value is true', (t) => {
+test('it should return the same source key value if the query key value is true', t => {
   t.plan(1);
   const source = {
     key: 'value'

--- a/test/querystring-implementation.js
+++ b/test/querystring-implementation.js
@@ -338,3 +338,17 @@ test('it should parse with space insensitivity', t => {
 
   t.deepEqual(actual, expected);
 });
+
+test('it should throw if the query is an unparseable string', t => {
+  t.plan(2);
+  const source = {
+    key: 'value'
+  };
+  const queries = ['', '{ hello }}'];
+
+  for (const query of queries) {
+    t.throws(() => {
+      objectql(source, query);
+    });
+  }
+});

--- a/test/querystring-implementation.js
+++ b/test/querystring-implementation.js
@@ -1,0 +1,303 @@
+/* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
+const tap = require('tap');
+const objectql = require('../');
+
+// shortcuts
+const test = tap.test;
+
+test('it ignore query keys that arent present in source object', t => {
+  t.plan(1);
+  const source = {
+    a: 'a',
+    b: 'b'
+  };
+  const query = `{
+    a
+    x {
+      y {
+        z
+      }
+    }
+  }`;
+
+  const actual = objectql(source, query);
+  const expected = {
+    a: 'a'
+  };
+
+  t.deepEqual(actual, expected);
+});
+
+test('it should return null if is source is null', t => {
+  t.plan(1);
+  const source = {
+    a: 'a',
+    b: 'b',
+    x: {
+      y: null
+    }
+  };
+  const query = `{
+    a
+    x {
+      y {
+        z
+      }
+    }
+  }`;
+
+  const actual = objectql(source, query);
+  const expected = {
+    a: 'a',
+    x: {
+      y: null
+    }
+  };
+
+  t.deepEqual(actual, expected);
+});
+
+test('it should pick entire values when the key is true', t => {
+  t.plan(1);
+
+  const source = {
+    a: 'a',
+    b: [1, 2, 3],
+    c: {
+      d: {
+        e: 'f'
+      }
+    },
+    g: 'meh',
+    h: false
+  };
+  const query = '{a,b,c,g,h}';
+
+  const expected = Object.assign({}, source);
+  const actual = objectql(source, query);
+
+  t.deepEqual(actual, expected);
+});
+
+test('it should operate on other keys in the query object recursively', t => {
+  t.plan(1);
+
+  const source = {
+    meh: 'to be trimed',
+    a: 'a',
+    b: {
+      meh: 'to be trimed',
+      c: {
+        meh: 'to be trimed',
+        d: 'd'
+      }
+    }
+  };
+  const query = '{ b { c { d } } }';
+
+  const actual = objectql(source, query);
+  const expected = {
+    b: {
+      c: {
+        d: 'd'
+      }
+    }
+  };
+
+  t.deepEqual(actual, expected);
+});
+
+test('it should iterate over arrays and apply the query for each item', t => {
+  t.plan(1);
+
+  const source = {
+    meh: 'to be trimed',
+    b: [
+      {
+        meh: 'to be trimed',
+        c: {
+          d: 'd'
+        }
+      },
+      {
+        meh: 'to be trimed',
+        c: {
+          d: 'd'
+        }
+      }
+    ]
+  };
+  const query = `{
+    b {
+      c { d }
+    }
+  }`;
+
+  const actual = objectql(source, query);
+  const expected = {
+    b: [
+      {
+        c: {
+          d: 'd'
+        }
+      },
+      {
+        c: {
+          d: 'd'
+        }
+      }
+    ]
+  };
+
+  t.deepEqual(actual, expected);
+});
+
+test('it should recursively iterate over arrays', t => {
+  t.plan(1);
+
+  const source = [
+    [
+      {
+        a: 'a',
+        b: {
+          c: [
+            {
+              d: 'd',
+              e: 'meh'
+            }
+          ]
+        },
+        z: 123
+      },
+      {
+        a: 'a',
+        b: {
+          c: [
+            {
+              d: 'd',
+              e: 'meh'
+            }
+          ]
+        },
+        z: 456
+      }
+    ]
+  ];
+
+  const query = `{
+    a
+    b {
+      c {
+        d
+      }
+    }
+  }`;
+
+  const actual = objectql(source, query);
+  const expected = [
+    [
+      {
+        a: 'a',
+        b: {
+          c: [
+            {
+              d: 'd'
+            }
+          ]
+        }
+      },
+      {
+        a: 'a',
+        b: {
+          c: [
+            {
+              d: 'd'
+            }
+          ]
+        }
+      }
+    ]
+  ];
+
+  t.deepEqual(actual, expected);
+});
+
+test('real life example', t => {
+  t.plan(1);
+
+  const source = {
+    id: '123',
+    modelName: 'model',
+    url: 'url',
+    date: Date.now(),
+    random: 'random',
+    photos: [
+      {
+        id: '123',
+        abc: 'abc'
+      }
+    ],
+    items: [
+      {
+        id: '456',
+        modelName: 'model',
+        url: 'url',
+        date: Date.now(),
+        photos: [
+          {
+            id: '123',
+            url: 'url'
+          }
+        ]
+      },
+      {
+        id: '789',
+        modelName: 'model',
+        url: 'url',
+        date: Date.now(),
+        photos: [
+          {
+            id: '123',
+            url: 'url'
+          }
+        ]
+      }
+    ]
+  };
+  const query = `{
+    id,
+    items {
+      modelName,
+      url,
+      photos {
+        url
+      }
+    }
+  }`;
+  const actual = objectql(source, query);
+  const expected = {
+    id: '123',
+    items: [
+      {
+        modelName: 'model',
+        url: 'url',
+        photos: [
+          {
+            url: 'url'
+          }
+        ]
+      },
+      {
+        modelName: 'model',
+        url: 'url',
+        photos: [
+          {
+            url: 'url'
+          }
+        ]
+      }
+    ]
+  };
+
+  t.deepEqual(actual, expected);
+});

--- a/test/querystring-implementation.js
+++ b/test/querystring-implementation.js
@@ -301,3 +301,40 @@ test('real life example', t => {
 
   t.deepEqual(actual, expected);
 });
+
+test('it should parse with space insensitivity', t => {
+  t.plan(5);
+
+  const source = {
+    meh: 'to be trimed',
+    a: 'a',
+    b: {
+      meh: 'to be trimed',
+      c: 'c',
+      d: {
+        meh: 'to be trimed',
+        e: 'e'
+      }
+    }
+  };
+  const queries = ['{a}', '{ a}', '{a }', '{ a }'];
+  let expected = { a: 'a' };
+  for (const query of queries) {
+    const actual = objectql(source, query);
+    t.deepEqual(actual, expected);
+  }
+
+  const query = '{a b{ c d { e }} }';
+  const actual = objectql(source, query);
+  expected = {
+    a: 'a',
+    b: {
+      c: 'c',
+      d: {
+        e: 'e'
+      }
+    }
+  };
+
+  t.deepEqual(actual, expected);
+});

--- a/test/querystring-implementation.js
+++ b/test/querystring-implementation.js
@@ -93,7 +93,7 @@ test('it should operate on other keys in the query object recursively', t => {
       }
     }
   };
-  const query = '{ b { c { d } } }';
+  const query = '{b{c{d}}}';
 
   const actual = objectql(source, query);
   const expected = {


### PR DESCRIPTION
These updates allow using a concise query `string`. Passing a query `object`
is still supported for backwards compatability, however, reference to using
the underlying object has been removed from the README to avoid creating
overly verbose usage documentation.